### PR TITLE
Remove duplicate tag from VIM help doc

### DIFF
--- a/doc/syntax_expand.txt
+++ b/doc/syntax_expand.txt
@@ -13,7 +13,7 @@ to "@". So you see and type "@" but Vim actually deals with the full syntax
 underneath.
 
 ===============================================================================
-Functions                                 *syntax_expand* *syntax_expand-functions*
+Functions                                                 *syntax_expand-functions*
 
 syntax_expand#expand({string}, {string})                  *syntax_expand#expand()*
     Attempts to swap the first string for the second one. If we are currently


### PR DESCRIPTION
Remove duplicate tag "syntax expand" from the VIM documentation txt. This fixes the command `:helptags ~/.vim/bundle/vim-syntax-expand/doc`.
